### PR TITLE
fix: fix error when report has no data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,9 +1638,9 @@
       }
     },
     "amazon-order-reports-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/amazon-order-reports-api/-/amazon-order-reports-api-3.3.1.tgz",
-      "integrity": "sha512-T8Xk65Jwt3kxl/yJMSHKPlwvYAP4d7lHvqAZMIzMCc563PLG+y5G3jyb2Mgdohxrqw9odWQUjBMBkseE2UJ1XA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/amazon-order-reports-api/-/amazon-order-reports-api-3.3.2.tgz",
+      "integrity": "sha512-Am27x+YqjgAfk2DIe7SPwPXvUIktli1ziQFofNoya4mEFuY9t5uhigPBxBTqEOM38ZZ2rh+IfGrWwOPkUe0Svw==",
       "requires": {
         "camelcase": "^5.3.1",
         "csv-parse": "^4.14.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "npm": ">=6.9.0"
   },
   "dependencies": {
-    "amazon-order-reports-api": "^3.3.1",
+    "amazon-order-reports-api": "^3.3.2",
     "env-paths": "^2.2.0",
     "hasha": "^5.2.2",
     "inquirer": "^6.5.2",


### PR DESCRIPTION
The application was throwing an UnhandledPromiseRejectionWarning when a report had no data. This was
due to an underlying bug in amazon-order-reports-api. This PR updates the library to the latest
version in which this is fixed.

fix #13